### PR TITLE
exit makes sense in rust because of the async/await implementation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04]
+        os: [ubuntu-24.04]
         rust: [stable]
         profile: [dev]
     name: test

--- a/stacks/src/bpf.rs
+++ b/stacks/src/bpf.rs
@@ -6,7 +6,7 @@ use libbpf_rs::{
     skel::{OpenSkel, SkelBuilder},
     Link,
 };
-use tracing::warn;
+use tracing::info;
 
 use crate::{
     perf_event::{attach_perf_event, perf_event_per_cpu},
@@ -629,20 +629,20 @@ pub(crate) fn link<'a>(
             .progs_mut()
             .stacks_tracing_exit()
             .attach_usdt(-1, u, "stacks_tracing", "exit")
-            .context("usdt exit")?;
+            .context("usdt exit");
+        match _usdt_exit {
+            Ok(link) => links.push(link),
+            Err(err) => {
+                info!("usdt exit is not attached to binary {:?}: {}", u, err);
+            }
+        }
         let _usdt_close = skel
             .progs_mut()
             .stacks_tracing_close()
             .attach_usdt(-1, u, "stacks_tracing", "close")
-            .context("usdt close");
-        match _usdt_close {
-            Ok(link) => links.push(link),
-            Err(err) => {
-                warn!("failed to attach usdt close to binary {:?}: {}", u, err);
-            }
-        }
+            .context("usdt close")?;
         links.push(_usdt_enter);
-        links.push(_usdt_exit);
+        links.push(_usdt_close);
     }
 
     Ok((skel, links))


### PR DESCRIPTION
in golang close will be called at exactly same time as exit, hence linking is optional