### PR TITLE
refactor consume-interrupt option away

### DIFF
--- a/e2e/tests/tests.rs
+++ b/e2e/tests/tests.rs
@@ -135,7 +135,6 @@ fn stacks_args(tmpdir: &Path, rows_per_file: u64) -> CommandArgs {
             format!("--dir={}", tmpdir.display()),
             format!("--rows={}", rows_per_file),
             format!("--groups-per-file=1"),
-            format!("--consume-interrupt"),
             format!("-p=profile:ku,switch:ku,rss:ku:1,block:ku,vfs:ku,net:ku"),
         ],
     }

--- a/stacks/src/bpf.rs
+++ b/stacks/src/bpf.rs
@@ -211,7 +211,7 @@ impl Display for Switch {
     }
 }
 
-impl<'a> TryFrom<Split<'a, char>> for Switch {
+impl TryFrom<Split<'_, char>> for Switch {
     type Error = anyhow::Error;
 
     fn try_from(value: Split<char>) -> Result<Self> {
@@ -258,7 +258,7 @@ impl Display for Profile {
     }
 }
 
-impl<'a> TryFrom<Split<'a, char>> for Profile {
+impl TryFrom<Split<'_, char>> for Profile {
     type Error = anyhow::Error;
 
     fn try_from(value: Split<char>) -> Result<Self> {
@@ -311,7 +311,7 @@ impl Display for Block {
     }
 }
 
-impl<'a> TryFrom<Split<'a, char>> for Block {
+impl TryFrom<Split<'_, char>> for Block {
     type Error = anyhow::Error;
 
     fn try_from(value: Split<char>) -> Result<Self> {
@@ -346,7 +346,7 @@ impl Display for Vfs {
     }
 }
 
-impl<'a> TryFrom<Split<'a, char>> for Vfs {
+impl TryFrom<Split<'_, char>> for Vfs {
     type Error = anyhow::Error;
 
     fn try_from(value: Split<char>) -> Result<Self> {
@@ -376,7 +376,7 @@ impl Display for Rss {
     }
 }
 
-impl<'a> TryFrom<Split<'a, char>> for Rss {
+impl TryFrom<Split<'_, char>> for Rss {
     type Error = anyhow::Error;
 
     fn try_from(value: Split<char>) -> Result<Self> {

--- a/stacks/src/bpf_profile.rs
+++ b/stacks/src/bpf_profile.rs
@@ -86,7 +86,7 @@ impl Display for DeltaStats {
 
 struct MultiLineStats<'a>(&'a [DeltaStats]);
 
-impl<'a> Display for MultiLineStats<'a> {
+impl Display for MultiLineStats<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.0.is_empty() {
             return Ok(());

--- a/stacks/src/main.rs
+++ b/stacks/src/main.rs
@@ -372,12 +372,9 @@ fn consume_events<Fr: Frames, Sym: Symbolizer>(
             }
         });
         if !interrupt.load(Ordering::Relaxed) {
-            info!("interrupted, dropping programs and consuming remaining events for 10s");
+            info!("interrupted, dropping programs and consuming remaining events");
             program_links.clear();
-            // 10s is an arbitrary timeout that must be sufficient to collect all remaining events
-            // in the ring buffer. if events are collected earlier poll will return earlier
-            // also poll can be interrupted again, if waiting is inconvinient
-            _ = mgr.poll(Duration::from_secs(10));
+            _ = mgr.consume();
 
             if let Some(profiler) = &profiler {
                 if let Err(err) = profiler.borrow_mut().log_stats(progs) {

--- a/stacks/src/state.rs
+++ b/stacks/src/state.rs
@@ -625,7 +625,7 @@ pub(crate) enum Received<'a> {
     TcpSend(&'a stacks_types::net_io_event),
 }
 
-impl<'a> Received<'a> {
+impl Received<'_> {
     pub(crate) fn program_name(&self) -> ProgramName {
         // TODO i need to have only one enum
         match self {

--- a/stacksexport/src/trace.rs
+++ b/stacksexport/src/trace.rs
@@ -129,7 +129,7 @@ pub(crate) async fn export(ctx: &SessionContext, queries: Vec<String>, out: &Pat
 #[derive(Debug)]
 struct EventsStream<'a>(Vec<RecordBatch>, &'a StackTraceGraph);
 
-impl<'a> Serialize for EventsStream<'a> {
+impl Serialize for EventsStream<'_> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,


### PR DESCRIPTION
it was very inconvenient to use, instead drop programs on interrupt so that new events are not generated
and always consume remaining events that were already in the ring buffer at the time of interrupt